### PR TITLE
Fix typo

### DIFF
--- a/src/languages/js/index.njk
+++ b/src/languages/js/index.njk
@@ -15,8 +15,8 @@ sm_img: sm_js.jpg
   Articles and talks about Javascript methods and expressions.<br>
 </p>
 <p>
-  As you can seen, there aren't many links at the moment. That's because I don't read a lot of Javascript related articles.<br>
-  It'd be awesome if you could help me extend this list by <a href="https://github.com/matuzo/front-end-bookmarks/#contributing" rel="noopener">contributing</a>.
+  As you can see, there aren't many links at the moment. That's because I don't read a lot of Javascript related articles.<br>
+  It'd be awesome, if you could help me extend this list by <a href="https://github.com/matuzo/front-end-bookmarks/#contributing" rel="noopener">contributing</a>.
 </p>
 
 {{macros.linklist("Methods", "js/methods", "methods")}}


### PR DESCRIPTION
Went on an Easter egg hunt :egg: and found a typo instead. :smile_cat:
Happy Easter! :tada: 

<div align="center">
<img src="https://media.giphy.com/media/Qw4X3FGaZ6y9cLu1EwE/giphy.gif" alt="Ralph picking up Easter egg" />
</div>